### PR TITLE
feat(classes): IO-74 Implement subject and subjectTag management features

### DIFF
--- a/src/main/java/edu/agh/dean/classesverifierbe/controller/SubjectController.java
+++ b/src/main/java/edu/agh/dean/classesverifierbe/controller/SubjectController.java
@@ -1,0 +1,78 @@
+package edu.agh.dean.classesverifierbe.controller;
+
+import edu.agh.dean.classesverifierbe.dto.SubjectDTO;
+import edu.agh.dean.classesverifierbe.RO.SubjectRO; // Make sure to import the RO class
+import edu.agh.dean.classesverifierbe.exceptions.SubjectAlreadyExistsException;
+import edu.agh.dean.classesverifierbe.exceptions.SubjectNotFoundException;
+import edu.agh.dean.classesverifierbe.exceptions.SubjectTagAlreadyExistsException;
+import edu.agh.dean.classesverifierbe.exceptions.SubjectTagNotFoundException;
+import edu.agh.dean.classesverifierbe.model.Subject;
+import edu.agh.dean.classesverifierbe.service.SubjectService;
+import jakarta.validation.Valid;
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/subjects")
+public class SubjectController {
+
+    private final SubjectService subjectService;
+    private final ModelMapper modelMapper;
+
+    @Autowired
+    public SubjectController(SubjectService subjectService, ModelMapper modelMapper) {
+        this.subjectService = subjectService;
+        this.modelMapper = modelMapper;
+    }
+
+    @PostMapping("/")
+    public ResponseEntity<Subject> createSubject(@RequestBody @Valid SubjectDTO subjectDTO) throws SubjectAlreadyExistsException {
+        Subject subject = modelMapper.map(subjectDTO, Subject.class);
+        Subject createdSubject = subjectService.createSubject(subject);
+        return ResponseEntity.ok(createdSubject);
+    }
+
+    @PutMapping("/{subjectId}")
+    public ResponseEntity<Subject> updateSubject(@PathVariable Long subjectId,@RequestBody @Valid SubjectDTO subjectDTO) throws SubjectNotFoundException {
+        Subject subject = modelMapper.map(subjectDTO, Subject.class);
+        Subject updatedSubject = subjectService.updateSubject(subjectId,subject);
+        return ResponseEntity.ok(updatedSubject);
+    }
+
+    @GetMapping("/")
+    public ResponseEntity<List<Subject>> getAllSubjects() throws SubjectNotFoundException{
+        List<Subject> subjects = subjectService.getAllSubjects();
+        return new ResponseEntity<>(subjects, HttpStatus.OK);
+    }
+
+
+
+    @DeleteMapping("/{subjectId}")
+    public ResponseEntity<Subject> deleteSubject(@PathVariable Long subjectId) throws SubjectNotFoundException {
+        Subject deletedSubject = subjectService.deleteSubject(subjectId);
+        return ResponseEntity.ok(deletedSubject);
+    }
+
+    @GetMapping("/{subjectId}")
+    public ResponseEntity<Subject> getSubjectById(@PathVariable Long subjectId) throws SubjectNotFoundException {
+        Subject subject = subjectService.getSubjectById(subjectId);
+        return ResponseEntity.ok(subject);
+    }
+
+    @PostMapping("/{subjectId}/tags/{tagId}")
+    public ResponseEntity<Subject> addTagToSubject(@PathVariable Long subjectId, @PathVariable Long tagId) throws SubjectNotFoundException, SubjectTagNotFoundException, SubjectTagAlreadyExistsException {
+        Subject updatedSubject = subjectService.addTagToSubject(subjectId, tagId);
+        return ResponseEntity.ok(updatedSubject);
+    }
+
+    @DeleteMapping("/{subjectId}/tags/{tagId}")
+    public ResponseEntity<Subject> removeTagFromSubject(@PathVariable Long subjectId, @PathVariable Long tagId) throws SubjectNotFoundException, SubjectTagNotFoundException{
+        Subject updatedSubject = subjectService.removeTagFromSubject(subjectId, tagId);
+        return ResponseEntity.ok(updatedSubject);
+    }
+}

--- a/src/main/java/edu/agh/dean/classesverifierbe/controller/SubjectController.java
+++ b/src/main/java/edu/agh/dean/classesverifierbe/controller/SubjectController.java
@@ -1,11 +1,10 @@
 package edu.agh.dean.classesverifierbe.controller;
 
+import edu.agh.dean.classesverifierbe.RO.UserRO;
 import edu.agh.dean.classesverifierbe.dto.SubjectDTO;
 import edu.agh.dean.classesverifierbe.RO.SubjectRO; // Make sure to import the RO class
-import edu.agh.dean.classesverifierbe.exceptions.SubjectAlreadyExistsException;
-import edu.agh.dean.classesverifierbe.exceptions.SubjectNotFoundException;
-import edu.agh.dean.classesverifierbe.exceptions.SubjectTagAlreadyExistsException;
-import edu.agh.dean.classesverifierbe.exceptions.SubjectTagNotFoundException;
+import edu.agh.dean.classesverifierbe.dto.UserDTO;
+import edu.agh.dean.classesverifierbe.exceptions.*;
 import edu.agh.dean.classesverifierbe.model.Subject;
 import edu.agh.dean.classesverifierbe.service.SubjectService;
 import jakarta.validation.Valid;
@@ -54,8 +53,6 @@ public class SubjectController {
         return ResponseEntity.ok(subjects);
     }
 
-
-
     @DeleteMapping("/{subjectId}")
     public ResponseEntity<Subject> deleteSubject(@PathVariable Long subjectId) throws SubjectNotFoundException {
         Subject deletedSubject = subjectService.deleteSubject(subjectId);
@@ -78,5 +75,12 @@ public class SubjectController {
     public ResponseEntity<Subject> removeTagFromSubject(@PathVariable Long subjectId, @PathVariable Long tagId) throws SubjectNotFoundException, SubjectTagNotFoundException{
         Subject updatedSubject = subjectService.removeTagFromSubject(subjectId, tagId);
         return ResponseEntity.ok(updatedSubject);
+    }
+
+    @GetMapping("/{subjectId}/users")
+    public ResponseEntity<List<UserRO>> getUsersEnrolledInSubjectForSemester(@PathVariable Long subjectId,
+                                                                              @RequestParam(required = false) Long semesterId) throws SubjectNotFoundException, SemesterNotFoundException {
+            List<UserRO> enrolledUsers = subjectService.getUsersEnrolledInSubjectForSemester(subjectId, semesterId);
+            return ResponseEntity.ok(enrolledUsers);
     }
 }

--- a/src/main/java/edu/agh/dean/classesverifierbe/controller/SubjectController.java
+++ b/src/main/java/edu/agh/dean/classesverifierbe/controller/SubjectController.java
@@ -11,6 +11,8 @@ import edu.agh.dean.classesverifierbe.service.SubjectService;
 import jakarta.validation.Valid;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -45,9 +47,11 @@ public class SubjectController {
     }
 
     @GetMapping("/")
-    public ResponseEntity<List<Subject>> getAllSubjects() throws SubjectNotFoundException{
-        List<Subject> subjects = subjectService.getAllSubjects();
-        return new ResponseEntity<>(subjects, HttpStatus.OK);
+    public ResponseEntity<Page<Subject>> getAllSubjects(Pageable pageable,
+                                                        @RequestParam(required = false) String tags,
+                                                        @RequestParam(required = false) String name) throws SubjectNotFoundException {
+        Page<Subject> subjects = subjectService.getAllSubjects(tags, name, pageable);
+        return ResponseEntity.ok(subjects);
     }
 
 

--- a/src/main/java/edu/agh/dean/classesverifierbe/controller/SubjectTagController.java
+++ b/src/main/java/edu/agh/dean/classesverifierbe/controller/SubjectTagController.java
@@ -1,0 +1,56 @@
+package edu.agh.dean.classesverifierbe.controller;
+
+import edu.agh.dean.classesverifierbe.RO.SubjectTagRO;
+import edu.agh.dean.classesverifierbe.dto.SubjectTagDTO;
+import edu.agh.dean.classesverifierbe.exceptions.SubjectTagAlreadyExistsException;
+import edu.agh.dean.classesverifierbe.exceptions.SubjectTagNotFoundException;
+import edu.agh.dean.classesverifierbe.service.SubjectTagService;
+import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/tags")
+public class SubjectTagController {
+
+    private final SubjectTagService tagService;
+
+    @Autowired
+    public SubjectTagController(SubjectTagService tagService) {
+        this.tagService = tagService;
+    }
+
+    @PostMapping("/")
+    public ResponseEntity<SubjectTagRO> createTag(@RequestBody @Valid SubjectTagDTO tagDto) throws SubjectTagAlreadyExistsException {
+        SubjectTagRO createdTag = tagService.createTag(tagDto);
+        return new ResponseEntity<>(createdTag, HttpStatus.CREATED);
+    }
+
+    @GetMapping("/")
+    public ResponseEntity<List<SubjectTagRO>> getAllTags() throws SubjectTagNotFoundException {
+        List<SubjectTagRO> tags = tagService.getAllTags();
+        return ResponseEntity.ok(tags);
+    }
+
+    @GetMapping("/{tagId}")
+    public ResponseEntity<SubjectTagRO> getTag(@PathVariable Long tagId) throws SubjectTagNotFoundException {
+        SubjectTagRO tag = tagService.getTag(tagId);
+        return ResponseEntity.ok(tag);
+    }
+
+    @PutMapping("/{tagId}")
+    public ResponseEntity<SubjectTagRO> updateTag(@PathVariable Long tagId, @RequestBody @Valid SubjectTagDTO tagDto) throws SubjectTagNotFoundException {
+        SubjectTagRO updatedTag = tagService.updateTag(tagId, tagDto);
+        return ResponseEntity.ok(updatedTag);
+    }
+
+    @DeleteMapping("/{tagId}")
+    public ResponseEntity<SubjectTagRO> deleteTag(@PathVariable Long tagId) throws SubjectTagNotFoundException {
+        SubjectTagRO deletedTag = tagService.deleteTag(tagId);
+        return ResponseEntity.ok(deletedTag);
+    }
+}

--- a/src/main/java/edu/agh/dean/classesverifierbe/dto/UserDTO.java
+++ b/src/main/java/edu/agh/dean/classesverifierbe/dto/UserDTO.java
@@ -28,5 +28,7 @@ public class UserDTO {
 
     private Role role;
 
+    private Long userId;
+
 
 }

--- a/src/main/java/edu/agh/dean/classesverifierbe/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/edu/agh/dean/classesverifierbe/exceptions/GlobalExceptionHandler.java
@@ -46,4 +46,41 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
     }
 
+    @ExceptionHandler({SemesterNotFoundException.class, SemesterAlreadyExistsException.class})
+    @ResponseBody
+    public ResponseEntity<?> handleSemesterExceptions(Exception ex) {
+        if (ex instanceof SemesterNotFoundException) {
+            return new ResponseEntity<>(ex.getMessage(), HttpStatus.NOT_FOUND);
+        }
+        else if(ex instanceof SemesterAlreadyExistsException){
+            return new ResponseEntity<>(ex.getMessage(), HttpStatus.CONFLICT);
+        }
+        return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler({SubjectNotFoundException.class, SubjectAlreadyExistsException.class})
+    @ResponseBody
+    public ResponseEntity<?> handleSubjectExceptions(Exception ex) {
+        if (ex instanceof SubjectNotFoundException) {
+            return new ResponseEntity<>(ex.getMessage(), HttpStatus.NOT_FOUND);
+        }
+        else if(ex instanceof SubjectAlreadyExistsException){
+            return new ResponseEntity<>(ex.getMessage(), HttpStatus.CONFLICT);
+        }
+        return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler({SubjectTagNotFoundException.class, SubjectTagAlreadyExistsException.class})
+    @ResponseBody
+    public ResponseEntity<?> handleSubjectTagExceptions(Exception ex) {
+        if (ex instanceof SubjectTagNotFoundException) {
+            return new ResponseEntity<>(ex.getMessage(), HttpStatus.NOT_FOUND);
+        }
+        else if(ex instanceof SubjectTagAlreadyExistsException){
+            return new ResponseEntity<>(ex.getMessage(), HttpStatus.CONFLICT);
+        }
+        return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
+    }
+
+
 }

--- a/src/main/java/edu/agh/dean/classesverifierbe/exceptions/SubjectAlreadyExistsException.java
+++ b/src/main/java/edu/agh/dean/classesverifierbe/exceptions/SubjectAlreadyExistsException.java
@@ -1,0 +1,19 @@
+package edu.agh.dean.classesverifierbe.exceptions;
+
+public class SubjectAlreadyExistsException extends Exception {
+
+    public SubjectAlreadyExistsException(String attribute, String value,String container) {
+        super("Subject with "+ attribute + " : " + value + " already exists in " + container);
+    }
+
+    public SubjectAlreadyExistsException(String attribute, String value) {
+        super("Subject with "+ attribute + " : " + value + " already exists");
+    }
+    public SubjectAlreadyExistsException(String attribute) {
+        super("Subject with given "+ attribute + " already exists");
+    }
+
+    public SubjectAlreadyExistsException() {
+        super("Subject already exists");
+    }
+}

--- a/src/main/java/edu/agh/dean/classesverifierbe/exceptions/SubjectNotFoundException.java
+++ b/src/main/java/edu/agh/dean/classesverifierbe/exceptions/SubjectNotFoundException.java
@@ -1,0 +1,19 @@
+package edu.agh.dean.classesverifierbe.exceptions;
+
+public class SubjectNotFoundException extends Exception {
+
+    public SubjectNotFoundException(String attribute, String value,String container) {
+        super("Subject with "+ attribute + " : " + value + " not found in " + container);
+    }
+
+    public SubjectNotFoundException(String attribute, String value) {
+        super("Subject with "+ attribute + " : " + value + " not found");
+    }
+    public SubjectNotFoundException(String attribute) {
+        super("Subject with given "+ attribute + " not found");
+    }
+
+    public SubjectNotFoundException() {
+        super("Subject not found");
+    }
+}

--- a/src/main/java/edu/agh/dean/classesverifierbe/exceptions/SubjectTagAlreadyExistsException.java
+++ b/src/main/java/edu/agh/dean/classesverifierbe/exceptions/SubjectTagAlreadyExistsException.java
@@ -1,0 +1,19 @@
+package edu.agh.dean.classesverifierbe.exceptions;
+
+public class SubjectTagAlreadyExistsException extends Exception {
+
+    public SubjectTagAlreadyExistsException(String attribute, String value,String container) {
+        super("SubjectTag with "+ attribute + " : " + value + " already exists in " + container);
+    }
+
+    public SubjectTagAlreadyExistsException(String attribute, String value) {
+        super("SubjectTag with "+ attribute + " : " + value + " already exists");
+    }
+    public SubjectTagAlreadyExistsException(String attribute) {
+        super("SubjectTag with given "+ attribute + " already exists");
+    }
+
+    public SubjectTagAlreadyExistsException() {
+        super("SubjectTag already exists");
+    }
+}

--- a/src/main/java/edu/agh/dean/classesverifierbe/exceptions/SubjectTagNotFoundException.java
+++ b/src/main/java/edu/agh/dean/classesverifierbe/exceptions/SubjectTagNotFoundException.java
@@ -1,0 +1,20 @@
+package edu.agh.dean.classesverifierbe.exceptions;
+
+public class SubjectTagNotFoundException extends Exception {
+
+    public SubjectTagNotFoundException(String attribute, String value,String container) {
+        super("SubjectTag with "+ attribute + " : " + value + " not found in " + container);
+    }
+
+    public SubjectTagNotFoundException(String attribute, String value) {
+        super("SubjectTag with "+ attribute + " : " + value + " not found");
+    }
+    public SubjectTagNotFoundException(String attribute) {
+        super("SubjectTag with given "+ attribute + " not found");
+    }
+
+
+    public SubjectTagNotFoundException() {
+        super("SubjectTag not found");
+    }
+}

--- a/src/main/java/edu/agh/dean/classesverifierbe/repository/EnrollmentRepository.java
+++ b/src/main/java/edu/agh/dean/classesverifierbe/repository/EnrollmentRepository.java
@@ -5,7 +5,9 @@ import edu.agh.dean.classesverifierbe.model.Semester;
 import edu.agh.dean.classesverifierbe.model.Subject;
 import edu.agh.dean.classesverifierbe.model.User;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface EnrollmentRepository extends CrudRepository<Enrollment, Long> {
     boolean existsByEnrollStudentAndEnrollSubjectAndSemester(User user, Subject subject, Semester currentSemester);
 

--- a/src/main/java/edu/agh/dean/classesverifierbe/repository/SemesterRepository.java
+++ b/src/main/java/edu/agh/dean/classesverifierbe/repository/SemesterRepository.java
@@ -4,9 +4,11 @@ import edu.agh.dean.classesverifierbe.model.Semester;
 import edu.agh.dean.classesverifierbe.model.enums.SemesterType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
+@Repository
 public interface SemesterRepository extends JpaRepository<Semester, Long> {
     @Query("SELECT s FROM Semester s WHERE s.deadline > CURRENT_DATE")
     Optional<Semester> findCurrentSemester();

--- a/src/main/java/edu/agh/dean/classesverifierbe/repository/SubjectRepository.java
+++ b/src/main/java/edu/agh/dean/classesverifierbe/repository/SubjectRepository.java
@@ -3,8 +3,11 @@ package edu.agh.dean.classesverifierbe.repository;
 import edu.agh.dean.classesverifierbe.model.Subject;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
+@Repository
 public interface SubjectRepository extends CrudRepository<Subject, Long> {
+    Subject findByName(String name);
 }

--- a/src/main/java/edu/agh/dean/classesverifierbe/repository/SubjectRepository.java
+++ b/src/main/java/edu/agh/dean/classesverifierbe/repository/SubjectRepository.java
@@ -1,6 +1,10 @@
 package edu.agh.dean.classesverifierbe.repository;
 
 import edu.agh.dean.classesverifierbe.model.Subject;
+import edu.agh.dean.classesverifierbe.model.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
@@ -10,4 +14,6 @@ import java.util.List;
 @Repository
 public interface SubjectRepository extends CrudRepository<Subject, Long> {
     Subject findByName(String name);
+
+    Page<Subject> findAll(Specification<Subject> spec, Pageable pageable);
 }

--- a/src/main/java/edu/agh/dean/classesverifierbe/repository/SubjectTagRepository.java
+++ b/src/main/java/edu/agh/dean/classesverifierbe/repository/SubjectTagRepository.java
@@ -4,11 +4,16 @@ import edu.agh.dean.classesverifierbe.model.SubjectTag;
 
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
+@Repository
 public interface SubjectTagRepository extends CrudRepository<SubjectTag, Long> {
     @Query("SELECT st FROM SubjectTag st JOIN st.subjects s WHERE s.subjectId = :subjectId")
     Set<SubjectTag> findSubjectTagsBySubjectId(Long subjectId);
+
+    Optional<SubjectTag> findByName(String name);
 }

--- a/src/main/java/edu/agh/dean/classesverifierbe/repository/SubjectTagRepository.java
+++ b/src/main/java/edu/agh/dean/classesverifierbe/repository/SubjectTagRepository.java
@@ -12,8 +12,5 @@ import java.util.Set;
 
 @Repository
 public interface SubjectTagRepository extends CrudRepository<SubjectTag, Long> {
-    @Query("SELECT st FROM SubjectTag st JOIN st.subjects s WHERE s.subjectId = :subjectId")
-    Set<SubjectTag> findSubjectTagsBySubjectId(Long subjectId);
-
     Optional<SubjectTag> findByName(String name);
 }

--- a/src/main/java/edu/agh/dean/classesverifierbe/service/SubjectService.java
+++ b/src/main/java/edu/agh/dean/classesverifierbe/service/SubjectService.java
@@ -54,8 +54,7 @@ public class SubjectService {
     }
 
     public Subject deleteSubject(Long subjectId) throws SubjectNotFoundException {
-        Subject subject = subjectRepository.findById(subjectId)
-                .orElseThrow(() -> new SubjectNotFoundException("subjectId"));
+        Subject subject = getSubjectById(subjectId);
 
         subject.getSubjectTags().clear();
         subjectRepository.delete(subject);
@@ -79,8 +78,7 @@ public class SubjectService {
 
 
     public Subject addTagToSubject(Long subjectId, Long tagId) throws SubjectNotFoundException, SubjectTagNotFoundException, SubjectTagAlreadyExistsException{
-        Subject subject = subjectRepository.findById(subjectId)
-                .orElseThrow(() -> new SubjectNotFoundException("subjectId"));
+        Subject subject = getSubjectById(subjectId);
         SubjectTag tag = subjectTagRepository.findById(tagId)
                 .orElseThrow(() -> new SubjectTagNotFoundException("tagId"));
 
@@ -94,8 +92,7 @@ public class SubjectService {
 
 
     public Subject removeTagFromSubject(Long subjectId, Long tagId) throws SubjectNotFoundException, SubjectTagNotFoundException{
-        Subject subject = subjectRepository.findById(subjectId)
-                .orElseThrow(() -> new SubjectNotFoundException("subjectId"));
+        Subject subject = getSubjectById(subjectId);
         SubjectTag tag = subjectTagRepository.findById(tagId)
                 .orElseThrow(() -> new SubjectTagNotFoundException("tagId"));
 

--- a/src/main/java/edu/agh/dean/classesverifierbe/service/SubjectService.java
+++ b/src/main/java/edu/agh/dean/classesverifierbe/service/SubjectService.java
@@ -1,0 +1,95 @@
+package edu.agh.dean.classesverifierbe.service;
+
+import edu.agh.dean.classesverifierbe.exceptions.SubjectAlreadyExistsException;
+import edu.agh.dean.classesverifierbe.exceptions.SubjectNotFoundException;
+import edu.agh.dean.classesverifierbe.exceptions.SubjectTagAlreadyExistsException;
+import edu.agh.dean.classesverifierbe.exceptions.SubjectTagNotFoundException;
+import edu.agh.dean.classesverifierbe.model.Subject;
+import edu.agh.dean.classesverifierbe.model.SubjectTag;
+import edu.agh.dean.classesverifierbe.repository.SubjectRepository;
+import edu.agh.dean.classesverifierbe.repository.SubjectTagRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+@Service
+@Transactional
+public class SubjectService {
+
+    private final SubjectRepository subjectRepository;
+    private final SubjectTagRepository subjectTagRepository;
+
+    @Autowired
+    public SubjectService(SubjectRepository subjectRepository, SubjectTagRepository subjectTagRepository) {
+        this.subjectRepository = subjectRepository;
+        this.subjectTagRepository = subjectTagRepository;
+    }
+
+    public Subject createSubject(Subject subject) throws SubjectAlreadyExistsException {
+        Subject foundSubject = subjectRepository.findByName(subject.getName());
+        if(foundSubject != null){
+            throw new SubjectAlreadyExistsException("name",subject.getName(),"subjects");
+        }
+        return subjectRepository.save(subject);
+    }
+
+    public Subject updateSubject(Long subjectId,Subject subject) throws SubjectNotFoundException {
+        Subject foundSubject = subjectRepository.findById(subjectId)
+                .orElseThrow(() -> new SubjectNotFoundException("subjectId"));
+        foundSubject.setName(subject.getName());
+        foundSubject.setDescription(subject.getDescription());
+        return subjectRepository.save(foundSubject);
+    }
+
+    public Subject deleteSubject(Long subjectId) throws SubjectNotFoundException {
+        Subject subject = subjectRepository.findById(subjectId)
+                .orElseThrow(() -> new SubjectNotFoundException("subjectId"));
+
+        subject.getSubjectTags().clear();
+        subjectRepository.delete(subject);
+        return subject;
+    }
+
+    public List<Subject> getAllSubjects() throws SubjectNotFoundException{
+        List <Subject> subjects = (List<Subject>) subjectRepository.findAll();
+        if(subjects.isEmpty()){
+            throw new SubjectNotFoundException();
+        }
+        return (List<Subject>) subjectRepository.findAll();
+    }
+
+    public Subject addTagToSubject(Long subjectId, Long tagId) throws SubjectNotFoundException, SubjectTagNotFoundException, SubjectTagAlreadyExistsException{
+        Subject subject = subjectRepository.findById(subjectId)
+                .orElseThrow(() -> new SubjectNotFoundException("subjectId"));
+        SubjectTag tag = subjectTagRepository.findById(tagId)
+                .orElseThrow(() -> new SubjectTagNotFoundException("tagId"));
+
+        if(subject.getSubjectTags().contains(tag)){
+            throw new SubjectTagAlreadyExistsException("tag",tag.toString(),"subjectTags");
+        }
+        subject.getSubjectTags().add(tag);
+        return subjectRepository.save(subject);
+    }
+
+
+
+    public Subject removeTagFromSubject(Long subjectId, Long tagId) throws SubjectNotFoundException, SubjectTagNotFoundException{
+        Subject subject = subjectRepository.findById(subjectId)
+                .orElseThrow(() -> new SubjectNotFoundException("subjectId"));
+        SubjectTag tag = subjectTagRepository.findById(tagId)
+                .orElseThrow(() -> new SubjectTagNotFoundException("tagId"));
+
+        if(!subject.getSubjectTags().contains(tag)){
+            throw new SubjectTagNotFoundException("tag",tag.toString(),"subjectTags");
+        }
+        subject.getSubjectTags().remove(tag);
+        return subjectRepository.save(subject);
+    }
+
+    public Subject getSubjectById(Long subjectId) throws SubjectNotFoundException {
+        return subjectRepository.findById(subjectId)
+                .orElseThrow(() -> new SubjectNotFoundException("subjectId"));
+    }
+
+}

--- a/src/main/java/edu/agh/dean/classesverifierbe/service/SubjectService.java
+++ b/src/main/java/edu/agh/dean/classesverifierbe/service/SubjectService.java
@@ -8,7 +8,11 @@ import edu.agh.dean.classesverifierbe.model.Subject;
 import edu.agh.dean.classesverifierbe.model.SubjectTag;
 import edu.agh.dean.classesverifierbe.repository.SubjectRepository;
 import edu.agh.dean.classesverifierbe.repository.SubjectTagRepository;
+import edu.agh.dean.classesverifierbe.specifications.SubjectSpecifications;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -51,13 +55,20 @@ public class SubjectService {
         return subject;
     }
 
-    public List<Subject> getAllSubjects() throws SubjectNotFoundException{
-        List <Subject> subjects = (List<Subject>) subjectRepository.findAll();
-        if(subjects.isEmpty()){
+    public Page<Subject> getAllSubjects(String tags, String name, Pageable pageable) throws SubjectNotFoundException {
+        Specification<Subject> spec = Specification
+                .where(SubjectSpecifications.withTags(tags))
+                .and(SubjectSpecifications.withNameLike(name));
+
+        Page<Subject> subjects = subjectRepository.findAll(spec, pageable);
+
+        if (subjects.isEmpty()) {
             throw new SubjectNotFoundException();
         }
-        return (List<Subject>) subjectRepository.findAll();
+
+        return subjects;
     }
+
 
     public Subject addTagToSubject(Long subjectId, Long tagId) throws SubjectNotFoundException, SubjectTagNotFoundException, SubjectTagAlreadyExistsException{
         Subject subject = subjectRepository.findById(subjectId)

--- a/src/main/java/edu/agh/dean/classesverifierbe/service/SubjectTagService.java
+++ b/src/main/java/edu/agh/dean/classesverifierbe/service/SubjectTagService.java
@@ -1,0 +1,70 @@
+package edu.agh.dean.classesverifierbe.service;
+
+import edu.agh.dean.classesverifierbe.RO.SubjectTagRO;
+import edu.agh.dean.classesverifierbe.dto.SubjectTagDTO;
+import edu.agh.dean.classesverifierbe.exceptions.SubjectTagAlreadyExistsException;
+import edu.agh.dean.classesverifierbe.exceptions.SubjectTagNotFoundException;
+import edu.agh.dean.classesverifierbe.model.SubjectTag;
+import edu.agh.dean.classesverifierbe.repository.SubjectTagRepository;
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.Optional;
+@Service
+public class SubjectTagService {
+
+    private final SubjectTagRepository subjectTagRepository;
+    private final ModelMapper modelMapper;
+
+    @Autowired
+    public SubjectTagService(SubjectTagRepository subjectTagRepository, ModelMapper modelMapper) {
+        this.subjectTagRepository = subjectTagRepository;
+        this.modelMapper = modelMapper;
+    }
+
+    public SubjectTagRO createTag(SubjectTagDTO tagDto) throws SubjectTagAlreadyExistsException {
+        Optional<SubjectTag> existingTag = subjectTagRepository.findByName(tagDto.getName());
+        if (existingTag.isPresent()) {
+            throw new SubjectTagAlreadyExistsException();
+        }
+
+        SubjectTag tag = modelMapper.map(tagDto, SubjectTag.class);
+        SubjectTag savedTag = subjectTagRepository.save(tag);
+        return modelMapper.map(savedTag, SubjectTagRO.class);
+    }
+
+    public List<SubjectTagRO> getAllTags() throws SubjectTagNotFoundException {
+        List<SubjectTag> tags =(List<SubjectTag>) subjectTagRepository.findAll();
+        if(tags.isEmpty()){
+            throw new SubjectTagNotFoundException();
+        }
+        return tags.stream()
+                .map(tag -> modelMapper.map(tag, SubjectTagRO.class))
+                .collect(Collectors.toList());
+    }
+
+    public SubjectTagRO getTag(Long tagId) throws SubjectTagNotFoundException {
+        SubjectTag tag = subjectTagRepository.findById(tagId)
+                .orElseThrow(() -> new SubjectTagNotFoundException("TagId",tagId.toString()));
+        return modelMapper.map(tag, SubjectTagRO.class);
+    }
+
+    public SubjectTagRO updateTag(Long tagId, SubjectTagDTO tagDto) throws SubjectTagNotFoundException {
+        SubjectTag existingTag = subjectTagRepository.findById(tagId)
+                .orElseThrow(() -> new SubjectTagNotFoundException("TagId",tagId.toString()));
+
+        existingTag.setName(tagDto.getName());
+        existingTag.setDescription(tagDto.getDescription());
+        SubjectTag updatedTag = subjectTagRepository.save(existingTag);
+        return modelMapper.map(updatedTag, SubjectTagRO.class);
+    }
+
+    public SubjectTagRO deleteTag(Long tagId) throws SubjectTagNotFoundException {
+        SubjectTag tag = subjectTagRepository.findById(tagId)
+                .orElseThrow(() -> new SubjectTagNotFoundException("TagId",tagId.toString()));
+        subjectTagRepository.delete(tag);
+        return modelMapper.map(tag, SubjectTagRO.class); // Zwracanie obiektu po usunięciu dla celów informacyjnych
+    }
+}

--- a/src/main/java/edu/agh/dean/classesverifierbe/specifications/SubjectSpecifications.java
+++ b/src/main/java/edu/agh/dean/classesverifierbe/specifications/SubjectSpecifications.java
@@ -1,0 +1,37 @@
+package edu.agh.dean.classesverifierbe.specifications;
+
+import edu.agh.dean.classesverifierbe.model.Subject;
+import edu.agh.dean.classesverifierbe.model.SubjectTag;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import org.springframework.data.jpa.domain.Specification;
+
+public class SubjectSpecifications {
+
+    public static Specification<Subject> withTags(String tags) {
+        return (root, query, cb) -> {
+            if (tags == null || tags.trim().isEmpty()) return null;
+
+            Join<Subject, SubjectTag> subjectTags = root.join("subjectTags");
+
+            String[] tagsArray = tags.split(",");
+            CriteriaBuilder.In<String> inClause = cb.in(subjectTags.get("name"));
+            for (String tag : tagsArray) {
+                inClause.value(tag);
+            }
+
+            return cb.and(inClause);
+        };
+    }
+
+    public static Specification<Subject> withNameLike(String name) {
+        return (root, query, cb) -> {
+            if (name == null || name.trim().isEmpty()) return null;
+
+            return cb.like(cb.lower(root.get("name")), "%" + name.toLowerCase() + "%");
+        };
+    }
+}
+

--- a/src/test/java/edu/agh/dean/classesverifierbe/controller/SemesterControllerTest.java
+++ b/src/test/java/edu/agh/dean/classesverifierbe/controller/SemesterControllerTest.java
@@ -1,0 +1,92 @@
+package edu.agh.dean.classesverifierbe.controller;
+import edu.agh.dean.classesverifierbe.RO.SubjectTagRO;
+import edu.agh.dean.classesverifierbe.dto.SemesterDTO;
+import edu.agh.dean.classesverifierbe.dto.SubjectTagDTO;
+import edu.agh.dean.classesverifierbe.exceptions.SemesterNotFoundException;
+import edu.agh.dean.classesverifierbe.model.Semester;
+import edu.agh.dean.classesverifierbe.model.enums.SemesterType;
+import edu.agh.dean.classesverifierbe.service.SemesterService;
+import edu.agh.dean.classesverifierbe.service.SubjectTagService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.*;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(SemesterController.class)
+class SemesterControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private SemesterService semesterService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void getAllSemestersShouldReturnListOfSemesters() throws Exception {
+        given(semesterService.getAllSemesters()).willReturn(List.of(new Semester(1L, SemesterType.WINTER, 2022, LocalDateTime.now())));
+
+        mockMvc.perform(get("/semester/"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].semesterType").value("WINTER"))
+                .andExpect(jsonPath("$[0].year").value(2022));
+
+        verify(semesterService).getAllSemesters();
+    }
+
+    @Test
+    void getSemesterByYearAndTypeShouldReturnSemester() throws Exception {
+        Integer year = 2022;
+        String type = "WINTER";
+        Semester foundSemester = new Semester(1L, SemesterType.valueOf(type), year, LocalDateTime.now());
+
+        given(semesterService.getSemesterByYearAndType(year, SemesterType.valueOf(type))).willReturn(foundSemester);
+
+        mockMvc.perform(get("/semester/year/{year}/type/{type}", year, type))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.semesterType").value("WINTER"))
+                .andExpect(jsonPath("$.year").value(2022));
+
+        verify(semesterService).getSemesterByYearAndType(year, SemesterType.valueOf(type));
+    }
+
+    @Test
+    void updateCurrentSemesterShouldReturnNotFoundWhenCurrentSemesterDoesNotExist() throws Exception {
+        SemesterDTO semesterDTO = new SemesterDTO();
+
+        semesterDTO.setSemesterType(SemesterType.SUMMER);
+        semesterDTO.setYear(2023);
+        semesterDTO.setDeadline(LocalDateTime.now().plusMonths(6));
+
+        given(semesterService.updateCurrentSemester(any(SemesterDTO.class))).willThrow(new SemesterNotFoundException("id"));
+
+        mockMvc.perform(put("/semester/current")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"semesterType\":\"SUMMER\",\"year\":2023,\"deadline\":\"" + LocalDateTime.now().plusMonths(6).toString() + "\"}"))
+                .andExpect(status().isNotFound());
+
+        verify(semesterService).updateCurrentSemester(any(SemesterDTO.class));
+    }
+
+
+
+
+}
+

--- a/src/test/java/edu/agh/dean/classesverifierbe/controller/SubjectControllerTest.java
+++ b/src/test/java/edu/agh/dean/classesverifierbe/controller/SubjectControllerTest.java
@@ -1,0 +1,153 @@
+package edu.agh.dean.classesverifierbe.controller;
+
+
+import edu.agh.dean.classesverifierbe.RO.UserRO;
+import edu.agh.dean.classesverifierbe.exceptions.SubjectNotFoundException;
+import edu.agh.dean.classesverifierbe.model.Subject;
+import edu.agh.dean.classesverifierbe.service.SubjectService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.mockito.MockitoAnnotations;
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(SubjectController.class)
+class SubjectControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private SubjectService subjectService;
+
+    @MockBean
+    private ModelMapper modelMapper;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void getAllSubjectsShouldReturnPageOfSubjects() throws Exception {
+
+        Subject subject = new Subject();
+        subject.setSubjectId(1L);
+        subject.setName("Algebra");
+        subject.setDescription("Detailed description of Algebra");
+
+        Page<Subject> pageOfSubjects = new PageImpl<>(Collections.singletonList(subject));
+
+        when(subjectService.getAllSubjects(eq("Math"), eq("Algebra"), any(Pageable.class)))
+                .thenReturn(pageOfSubjects);
+
+        mockMvc.perform(get("/subjects/")
+                        .param("tags", "Math")
+                        .param("name", "Algebra"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.content[0].name").value("Algebra"))
+                .andExpect(jsonPath("$.content[0].description").value("Detailed description of Algebra"));
+
+        verify(subjectService).getAllSubjects(eq("Math"), eq("Algebra"), any(Pageable.class));
+    }
+
+
+    @Test
+    void addTagToSubjectShouldReturnOkWhenSuccess() throws Exception {
+
+        Subject subject = new Subject();
+        when(subjectService.addTagToSubject(anyLong(), anyLong())).thenReturn(subject);
+
+        mockMvc.perform(post("/subjects/1/tags/1")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+        verify(subjectService).addTagToSubject(1L, 1L);
+    }
+
+    @Test
+    void addTagToSubjectShouldReturnNotFoundWhenSubjectNotFound() throws Exception {
+
+        when(subjectService.addTagToSubject(anyLong(), anyLong())).thenThrow(new SubjectNotFoundException("subjectId"));
+
+        mockMvc.perform(post("/subjects/999/tags/1")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound());
+    }
+
+
+    @Test
+    void getUsersEnrolledInSubjectForSemesterShouldReturnListOfUsers() throws Exception {
+
+        Long subjectId = 1L;
+        Long semesterId = 1L;
+
+        List<UserRO> mockUsers = new ArrayList<>();
+        UserRO user = UserRO.builder()
+                .userId(1L)
+                .firstName("John")
+                .lastName("Doe")
+                .email("john.doe@example.com")
+                .indexNumber("123456")
+                .build();
+        mockUsers.add(user);
+
+        when(subjectService.getUsersEnrolledInSubjectForSemester(subjectId, semesterId)).thenReturn(mockUsers);
+
+
+        mockMvc.perform(get("/subjects/{subjectId}/users", subjectId)
+                        .param("semesterId", semesterId.toString())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$[0].userId").value(mockUsers.get(0).getUserId()))
+                .andExpect(jsonPath("$[0].firstName").value("John"))
+                .andExpect(jsonPath("$[0].lastName").value("Doe"))
+                .andExpect(jsonPath("$[0].email").value("john.doe@example.com"))
+                .andExpect(jsonPath("$[0].indexNumber").value("123456"));
+
+
+        verify(subjectService).getUsersEnrolledInSubjectForSemester(subjectId, semesterId);
+    }
+
+    @Test
+    void getUsersEnrolledInSubjectForSemesterShouldReturnNotFoundWhenSubjectNotFound() throws Exception {
+
+        Long subjectId = 999L;
+        Long semesterId = 1L;
+
+        when(subjectService.getUsersEnrolledInSubjectForSemester(subjectId, semesterId))
+                .thenThrow(new SubjectNotFoundException());
+
+        mockMvc.perform(get("/subjects/{subjectId}/users", subjectId)
+                        .param("semesterId", semesterId.toString())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound());
+
+        verify(subjectService).getUsersEnrolledInSubjectForSemester(subjectId, semesterId);
+    }
+
+
+
+
+
+}
+

--- a/src/test/java/edu/agh/dean/classesverifierbe/controller/SubjectTagControllerTest.java
+++ b/src/test/java/edu/agh/dean/classesverifierbe/controller/SubjectTagControllerTest.java
@@ -1,0 +1,92 @@
+package edu.agh.dean.classesverifierbe.controller;
+
+import edu.agh.dean.classesverifierbe.RO.SubjectTagRO;
+import edu.agh.dean.classesverifierbe.dto.SubjectTagDTO;
+import edu.agh.dean.classesverifierbe.exceptions.SubjectTagNotFoundException;
+import edu.agh.dean.classesverifierbe.service.SubjectTagService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(SubjectTagController.class)
+class SubjectTagControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private SubjectTagService tagService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void createTagShouldReturnCreatedTag() throws Exception {
+        SubjectTagDTO tagDto = new SubjectTagDTO();
+        tagDto.setName("Math");
+        tagDto.setDescription("Mathematics Description");
+
+        SubjectTagRO createdTag = new SubjectTagRO(1, "Math", "Mathematics Description");
+
+        given(tagService.createTag(any(SubjectTagDTO.class))).willReturn(createdTag);
+
+        mockMvc.perform(post("/tags/")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"Math\",\"description\":\"Mathematics Description\"}"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.name").value("Math"));
+
+        verify(tagService).createTag(any(SubjectTagDTO.class));
+    }
+
+    @Test
+    void getTagShouldReturnNotFoundWhenTagDoesNotExist() throws Exception {
+        Long tagId = 999L;
+        given(tagService.getTag(tagId)).willThrow(new SubjectTagNotFoundException());
+
+        mockMvc.perform(get("/tags/{tagId}", tagId))
+                .andExpect(status().isNotFound());
+
+        verify(tagService).getTag(tagId);
+    }
+
+    @Test
+    void updateTagShouldReturnUpdatedTag() throws Exception {
+        Long tagId = 1L;
+        int tagIntId = 1;
+        SubjectTagDTO tagDto = new SubjectTagDTO();
+        tagDto.setName("UpdatedName");
+        tagDto.setDescription("Updated Description");
+        SubjectTagRO updatedTag = new SubjectTagRO();
+        updatedTag.setName("UpdatedName");
+        updatedTag.setDescription("Updated Description");
+        updatedTag.setSubjectTagId(tagIntId);
+        given(tagService.updateTag(eq(tagId), any(SubjectTagDTO.class))).willReturn(updatedTag);
+
+        mockMvc.perform(put("/tags/{tagId}", tagId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"UpdatedName\",\"description\":\"Updated Description\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("UpdatedName"))
+                .andExpect(jsonPath("$.description").value("Updated Description"));
+
+        verify(tagService).updateTag(eq(tagId), any(SubjectTagDTO.class));
+    }
+
+
+
+}

--- a/src/test/java/edu/agh/dean/classesverifierbe/service/SemesterServiceTest.java
+++ b/src/test/java/edu/agh/dean/classesverifierbe/service/SemesterServiceTest.java
@@ -1,0 +1,85 @@
+package edu.agh.dean.classesverifierbe.service;
+
+
+import edu.agh.dean.classesverifierbe.dto.SemesterDTO;
+import edu.agh.dean.classesverifierbe.exceptions.SemesterAlreadyExistsException;
+import edu.agh.dean.classesverifierbe.exceptions.SemesterNotFoundException;
+import edu.agh.dean.classesverifierbe.model.Semester;
+import edu.agh.dean.classesverifierbe.model.enums.SemesterType;
+import edu.agh.dean.classesverifierbe.repository.SemesterRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+class SemesterServiceTest {
+
+    @Mock
+    private SemesterRepository semesterRepository;
+
+    @InjectMocks
+    private SemesterService semesterService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void getSemesterByIdShouldReturnSemesterWhenFound() throws SemesterNotFoundException {
+        Semester expectedSemester = new Semester(1L, SemesterType.WINTER, 2022, LocalDateTime.now());
+        when(semesterRepository.findById(1L)).thenReturn(Optional.of(expectedSemester));
+
+        Semester result = semesterService.getSemesterById(1L);
+
+        assertEquals(expectedSemester, result);
+        verify(semesterRepository).findById(1L);
+    }
+
+    @Test
+    void getSemesterByIdShouldThrowWhenNotFound() {
+        when(semesterRepository.findById(anyLong())).thenReturn(Optional.empty());
+
+        assertThrows(SemesterNotFoundException.class, () -> semesterService.getSemesterById(999L));
+    }
+
+
+    @Test
+    void createSemesterShouldThrowWhenSemesterAlreadyExists() {
+        SemesterDTO semesterDTO = new SemesterDTO();
+        semesterDTO.setSemesterType(SemesterType.WINTER);
+        semesterDTO.setYear(2022);
+        semesterDTO.setDeadline(LocalDateTime.now());
+        when(semesterRepository.findByYearAndSemesterType(2022, SemesterType.WINTER))
+                .thenReturn(Optional.of(new Semester()));
+
+        assertThrows(SemesterAlreadyExistsException.class, () -> semesterService.createSemester(semesterDTO));
+    }
+
+    @Test
+    void createSemesterShouldCreateWhenNotExists() throws SemesterAlreadyExistsException {
+        SemesterDTO semesterDTO = new SemesterDTO();
+        semesterDTO.setSemesterType(SemesterType.WINTER);
+        semesterDTO.setYear(2022);
+        semesterDTO.setDeadline(LocalDateTime.now());
+        when(semesterRepository.findByYearAndSemesterType(2022, SemesterType.WINTER))
+                .thenReturn(Optional.empty());
+
+        semesterService.createSemester(semesterDTO);
+
+        verify(semesterRepository).save(any(Semester.class));
+    }
+
+}
+

--- a/src/test/java/edu/agh/dean/classesverifierbe/service/SubjectServiceTest.java
+++ b/src/test/java/edu/agh/dean/classesverifierbe/service/SubjectServiceTest.java
@@ -1,7 +1,11 @@
 package edu.agh.dean.classesverifierbe.service;
 
+import edu.agh.dean.classesverifierbe.RO.UserRO;
+import edu.agh.dean.classesverifierbe.exceptions.SemesterNotFoundException;
 import edu.agh.dean.classesverifierbe.exceptions.SubjectNotFoundException;
-import edu.agh.dean.classesverifierbe.model.Subject;
+import edu.agh.dean.classesverifierbe.exceptions.SubjectTagAlreadyExistsException;
+import edu.agh.dean.classesverifierbe.model.*;
+import edu.agh.dean.classesverifierbe.model.enums.SemesterType;
 import edu.agh.dean.classesverifierbe.repository.SubjectRepository;
 import edu.agh.dean.classesverifierbe.repository.SubjectTagRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -9,8 +13,15 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import java.util.Optional;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.time.LocalDateTime;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -51,5 +62,132 @@ class SubjectServiceTest {
             subjectService.getSubjectById(1L);
         });
     }
+
+
+    @Test
+    void getUsersEnrolledInSubjectForSemesterShouldReturnUsers() throws SubjectNotFoundException, SemesterNotFoundException {
+        Long subjectId = 1L;
+        Long semesterId = 1L;
+
+        Subject subject = mock(Subject.class);
+        User user = User.builder()
+                .userId(1L)
+                .firstName("John")
+                .lastName("Doe")
+                .email("john.doe@example.com")
+                .indexNumber("123456")
+                .build();
+        Enrollment enrollment = new Enrollment();
+        enrollment.setEnrollStudent(user);
+        enrollment.setSemester(new Semester(semesterId, SemesterType.WINTER, 2021, LocalDateTime.now()));
+        Set<Enrollment> enrollments = new HashSet<>();
+        enrollments.add(enrollment);
+        when(subject.getEnrollments()).thenReturn(enrollments);
+
+        when(subjectRepository.findById(subjectId)).thenReturn(Optional.of(subject));
+
+        List<UserRO> result = subjectService.getUsersEnrolledInSubjectForSemester(subjectId, semesterId);
+
+
+        verify(subjectRepository).findById(subjectId);
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+        assertEquals(1, result.size());
+        assertEquals("John", result.get(0).getFirstName());
+        assertEquals("Doe", result.get(0).getLastName());
+    }
+
+
+
+    @Test
+    void shouldFilterSubjectsByTagsAndName() throws SubjectNotFoundException {
+
+        PageRequest pageable = PageRequest.of(0, 10);
+        String tags = "Math,Science";
+        String name = "Algebra";
+
+        Subject subject = new Subject();
+        subject.setName("Algebra 101");
+
+
+        when(subjectRepository.findAll(any(Specification.class), eq(pageable)))
+                .thenReturn(new PageImpl<>(Collections.singletonList(subject)));
+
+
+        Page<Subject> result = subjectService.getAllSubjects(tags, name, pageable);
+
+        verify(subjectRepository).findAll(any(Specification.class), eq(pageable));
+        assertFalse(result.isEmpty());
+        assertEquals(1, result.getContent().size());
+        assertEquals("Algebra 101", result.getContent().get(0).getName());
+    }
+
+    @Test
+    void shouldThrowSubjectNotFoundExceptionWhenNoSubjectsFound() {
+
+        PageRequest pageable = PageRequest.of(0, 10);
+        String tags = "Nonexistent";
+        String name = "Nonexistent";
+
+        when(subjectRepository.findAll(any(Specification.class), eq(pageable)))
+                .thenReturn(Page.empty());
+
+        assertThrows(SubjectNotFoundException.class, () -> {
+            subjectService.getAllSubjects(tags, name, pageable);
+        });
+    }
+
+    @Test
+    void shouldAddTagToSubjectSuccessfully() throws Exception {
+
+        Long subjectId = 1L;
+        Long tagId = 1L;
+
+        Subject subject = Subject.builder()
+                .subjectId(subjectId)
+                .name("Math")
+                .subjectTags(new HashSet<>())
+                .build();
+
+        SubjectTag tag = new SubjectTag(1, "Calculus", "Calculus description", new HashSet<>());
+
+        when(subjectRepository.findById(subjectId)).thenReturn(Optional.of(subject));
+        when(subjectTagRepository.findById(tagId)).thenReturn(Optional.of(tag));
+
+
+        subjectService.addTagToSubject(subjectId, tagId);
+
+
+        assertTrue(subject.getSubjectTags().contains(tag));
+        verify(subjectRepository).save(subject);
+    }
+
+    @Test
+    void shouldThrowSubjectTagAlreadyExistsExceptionIfTagAlreadyAssigned() {
+        Long subjectId = 1L;
+        Long tagId = 1L;
+
+        SubjectTag tag = new SubjectTag(1, "Calculus", "Calculus description", new HashSet<>());
+        Set<SubjectTag> tags = new HashSet<>();
+        tags.add(tag);
+
+        Subject subject = Subject.builder()
+                .subjectId(subjectId)
+                .name("Math")
+                .subjectTags(tags)
+                .build();
+
+        when(subjectRepository.findById(subjectId)).thenReturn(Optional.of(subject));
+        when(subjectTagRepository.findById(tagId)).thenReturn(Optional.of(tag));
+
+
+        assertThrows(SubjectTagAlreadyExistsException.class, () -> {
+            subjectService.addTagToSubject(subjectId, tagId);
+        });
+    }
 }
+
+
+
+
 

--- a/src/test/java/edu/agh/dean/classesverifierbe/service/SubjectServiceTest.java
+++ b/src/test/java/edu/agh/dean/classesverifierbe/service/SubjectServiceTest.java
@@ -1,0 +1,55 @@
+package edu.agh.dean.classesverifierbe.service;
+
+import edu.agh.dean.classesverifierbe.exceptions.SubjectNotFoundException;
+import edu.agh.dean.classesverifierbe.model.Subject;
+import edu.agh.dean.classesverifierbe.repository.SubjectRepository;
+import edu.agh.dean.classesverifierbe.repository.SubjectTagRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import java.util.Optional;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class SubjectServiceTest {
+
+    @Mock
+    private SubjectRepository subjectRepository;
+
+    @Mock
+    private SubjectTagRepository subjectTagRepository;
+
+    @InjectMocks
+    private SubjectService subjectService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void createSubjectSuccessful() throws Exception {
+        Subject subject = new Subject();
+        subject.setName("Math");
+
+        when(subjectRepository.findByName(anyString())).thenReturn(null);
+        when(subjectRepository.save(any(Subject.class))).thenReturn(subject);
+
+        subjectService.createSubject(subject);
+
+        verify(subjectRepository).save(any(Subject.class));
+    }
+
+    @Test
+    void getSubjectByIdNotFound() {
+        when(subjectRepository.findById(anyLong())).thenReturn(Optional.empty());
+
+        assertThrows(SubjectNotFoundException.class, () -> {
+            subjectService.getSubjectById(1L);
+        });
+    }
+}
+

--- a/src/test/java/edu/agh/dean/classesverifierbe/service/SubjectTagServiceTest.java
+++ b/src/test/java/edu/agh/dean/classesverifierbe/service/SubjectTagServiceTest.java
@@ -1,0 +1,77 @@
+package edu.agh.dean.classesverifierbe.service;
+
+import edu.agh.dean.classesverifierbe.RO.SubjectTagRO;
+import edu.agh.dean.classesverifierbe.dto.SubjectTagDTO;
+import edu.agh.dean.classesverifierbe.exceptions.SubjectTagAlreadyExistsException;
+import edu.agh.dean.classesverifierbe.exceptions.SubjectTagNotFoundException;
+import edu.agh.dean.classesverifierbe.model.SubjectTag;
+import edu.agh.dean.classesverifierbe.repository.SubjectTagRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.modelmapper.ModelMapper;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class SubjectTagServiceTest {
+
+    @Mock
+    private SubjectTagRepository subjectTagRepository;
+
+    @Mock
+    private ModelMapper modelMapper;
+
+    @InjectMocks
+    private SubjectTagService subjectTagService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void createTagSuccessful() throws SubjectTagAlreadyExistsException {
+        SubjectTagDTO tagDto = new SubjectTagDTO();
+        tagDto.setName("Math");
+        tagDto.setDescription("Mathematics");
+
+        SubjectTag tag = new SubjectTag();
+        tag.setName("Math");
+        tag.setDescription("Mathematics");
+
+        SubjectTagRO tagRO = new SubjectTagRO();
+        tagRO.setName(tag.getName());
+        tagRO.setDescription(tag.getDescription());
+
+        when(modelMapper.map(tagDto, SubjectTag.class)).thenReturn(tag);
+        when(modelMapper.map(tag, SubjectTagRO.class)).thenReturn(tagRO);
+        when(subjectTagRepository.save(tag)).thenReturn(tag);
+
+        SubjectTagRO createdTag = subjectTagService.createTag(tagDto);
+
+
+        verify(modelMapper).map(tagDto, SubjectTag.class);
+        verify(subjectTagRepository).save(tag);
+        verify(modelMapper).map(tag, SubjectTagRO.class);
+
+        assertEquals("Math", createdTag.getName());
+        assertEquals("Mathematics", createdTag.getDescription());
+    }
+
+
+    @Test
+    void getTagNotFound() {
+        when(subjectTagRepository.findById(anyLong())).thenReturn(Optional.empty());
+
+        assertThrows(SubjectTagNotFoundException.class, () -> {
+            subjectTagService.getTag(1L);
+        });
+    }
+}
+


### PR DESCRIPTION
- Implement CRUD operations for subjects, providing a foundation for subject management within the platform.
- Implement CRUD operations for subjectTags, enabling comprehensive subjectTag management.
- Introduce functionality for assigning and detaching subjects to/from subjectTags, enhancing the flexibility of subject categorization.
- Enhance subject search capabilities by adding filtering and sorting options, improving user experience in locating specific subjects.
- Enable searching for students based on their enrollment in subjects during a specific semester, facilitating the tracking of student subject participation.


