### PR TITLE
fix(classes): IO-76 rename endpoints

### DIFF
--- a/src/main/java/edu/agh/dean/classesverifierbe/controller/SemesterController.java
+++ b/src/main/java/edu/agh/dean/classesverifierbe/controller/SemesterController.java
@@ -35,7 +35,7 @@ public class SemesterController {
     public ResponseEntity<String> handleSemesterAlreadyExists(SemesterAlreadyExistsException exception) {
         return ResponseEntity.badRequest().body(exception.getMessage());
     }
-    @PostMapping("/")
+    @PostMapping
     @ResponseBody
     public ResponseEntity<?> createSemester(@Valid @RequestBody SemesterDTO semesterDTO) {
         try {
@@ -46,7 +46,7 @@ public class SemesterController {
         }
     }
 
-    @GetMapping("/")
+    @GetMapping
     @ResponseBody
     public ResponseEntity<?> getAllSemesters() {
         return ResponseEntity.ok(semesterService.getAllSemesters());

--- a/src/main/java/edu/agh/dean/classesverifierbe/controller/SemesterController.java
+++ b/src/main/java/edu/agh/dean/classesverifierbe/controller/SemesterController.java
@@ -18,7 +18,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 @RestController
-@RequestMapping("/semester")
+@RequestMapping("/semesters")
 public class SemesterController {
 
     @Autowired

--- a/src/main/java/edu/agh/dean/classesverifierbe/controller/StudentController.java
+++ b/src/main/java/edu/agh/dean/classesverifierbe/controller/StudentController.java
@@ -21,7 +21,7 @@ import java.util.*;
 
 
 @RestController
-@RequestMapping("/student")
+@RequestMapping("/students")
 public class StudentController {
 
     @Autowired

--- a/src/main/java/edu/agh/dean/classesverifierbe/controller/StudentController.java
+++ b/src/main/java/edu/agh/dean/classesverifierbe/controller/StudentController.java
@@ -28,7 +28,7 @@ public class StudentController {
     private StudentService studentService;
 
 
-    @PostMapping("/")
+    @PostMapping
     public ResponseEntity<?> addUser(@Valid @RequestBody UserDTO userDto) {
         try {
             User newUser = studentService.addUser(userDto);
@@ -58,7 +58,7 @@ public class StudentController {
 
 
 
-    @GetMapping("/")
+    @GetMapping
     public ResponseEntity<Page<UserRO>> getStudents(Pageable pageable,
                                                     @RequestParam(required = false) String tag,
                                                     @RequestParam(required = false) String name,

--- a/src/main/java/edu/agh/dean/classesverifierbe/controller/SubjectController.java
+++ b/src/main/java/edu/agh/dean/classesverifierbe/controller/SubjectController.java
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/subject")
+@RequestMapping("/subjects")
 public class SubjectController {
 
     private final SubjectService subjectService;

--- a/src/main/java/edu/agh/dean/classesverifierbe/controller/SubjectController.java
+++ b/src/main/java/edu/agh/dean/classesverifierbe/controller/SubjectController.java
@@ -31,7 +31,7 @@ public class SubjectController {
         this.modelMapper = modelMapper;
     }
 
-    @PostMapping("/")
+    @PostMapping
     public ResponseEntity<Subject> createSubject(@RequestBody @Valid SubjectDTO subjectDTO) throws SubjectAlreadyExistsException {
         Subject subject = modelMapper.map(subjectDTO, Subject.class);
         Subject createdSubject = subjectService.createSubject(subject);
@@ -45,7 +45,7 @@ public class SubjectController {
         return ResponseEntity.ok(updatedSubject);
     }
 
-    @GetMapping("/")
+    @GetMapping
     public ResponseEntity<Page<Subject>> getAllSubjects(Pageable pageable,
                                                         @RequestParam(required = false) String tags,
                                                         @RequestParam(required = false) String name) throws SubjectNotFoundException {

--- a/src/main/java/edu/agh/dean/classesverifierbe/controller/SubjectController.java
+++ b/src/main/java/edu/agh/dean/classesverifierbe/controller/SubjectController.java
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/subjects")
+@RequestMapping("/subject")
 public class SubjectController {
 
     private final SubjectService subjectService;

--- a/src/main/java/edu/agh/dean/classesverifierbe/controller/SubjectTagController.java
+++ b/src/main/java/edu/agh/dean/classesverifierbe/controller/SubjectTagController.java
@@ -24,13 +24,13 @@ public class SubjectTagController {
         this.tagService = tagService;
     }
 
-    @PostMapping("/")
+    @PostMapping
     public ResponseEntity<SubjectTagRO> createTag(@RequestBody @Valid SubjectTagDTO tagDto) throws SubjectTagAlreadyExistsException {
         SubjectTagRO createdTag = tagService.createTag(tagDto);
         return new ResponseEntity<>(createdTag, HttpStatus.CREATED);
     }
 
-    @GetMapping("/")
+    @GetMapping
     public ResponseEntity<List<SubjectTagRO>> getAllTags() throws SubjectTagNotFoundException {
         List<SubjectTagRO> tags = tagService.getAllTags();
         return ResponseEntity.ok(tags);

--- a/src/main/java/edu/agh/dean/classesverifierbe/controller/SubjectTagController.java
+++ b/src/main/java/edu/agh/dean/classesverifierbe/controller/SubjectTagController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/tags")
+@RequestMapping("/tag")
 public class SubjectTagController {
 
     private final SubjectTagService tagService;

--- a/src/main/java/edu/agh/dean/classesverifierbe/controller/SubjectTagController.java
+++ b/src/main/java/edu/agh/dean/classesverifierbe/controller/SubjectTagController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/tag")
+@RequestMapping("/tags")
 public class SubjectTagController {
 
     private final SubjectTagService tagService;

--- a/src/test/java/edu/agh/dean/classesverifierbe/controller/SemesterControllerTest.java
+++ b/src/test/java/edu/agh/dean/classesverifierbe/controller/SemesterControllerTest.java
@@ -43,7 +43,7 @@ class SemesterControllerTest {
     void getAllSemestersShouldReturnListOfSemesters() throws Exception {
         given(semesterService.getAllSemesters()).willReturn(List.of(new Semester(1L, SemesterType.WINTER, 2022, LocalDateTime.now())));
 
-        mockMvc.perform(get("/semester/"))
+        mockMvc.perform(get("/semester"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].semesterType").value("WINTER"))
                 .andExpect(jsonPath("$[0].year").value(2022));

--- a/src/test/java/edu/agh/dean/classesverifierbe/controller/SemesterControllerTest.java
+++ b/src/test/java/edu/agh/dean/classesverifierbe/controller/SemesterControllerTest.java
@@ -43,7 +43,7 @@ class SemesterControllerTest {
     void getAllSemestersShouldReturnListOfSemesters() throws Exception {
         given(semesterService.getAllSemesters()).willReturn(List.of(new Semester(1L, SemesterType.WINTER, 2022, LocalDateTime.now())));
 
-        mockMvc.perform(get("/semester"))
+        mockMvc.perform(get("/semesters"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].semesterType").value("WINTER"))
                 .andExpect(jsonPath("$[0].year").value(2022));
@@ -59,7 +59,7 @@ class SemesterControllerTest {
 
         given(semesterService.getSemesterByYearAndType(year, SemesterType.valueOf(type))).willReturn(foundSemester);
 
-        mockMvc.perform(get("/semester/year/{year}/type/{type}", year, type))
+        mockMvc.perform(get("/semesters/year/{year}/type/{type}", year, type))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.semesterType").value("WINTER"))
                 .andExpect(jsonPath("$.year").value(2022));
@@ -77,7 +77,7 @@ class SemesterControllerTest {
 
         given(semesterService.updateCurrentSemester(any(SemesterDTO.class))).willThrow(new SemesterNotFoundException("id"));
 
-        mockMvc.perform(put("/semester/current")
+        mockMvc.perform(put("/semesters/current")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"semesterType\":\"SUMMER\",\"year\":2023,\"deadline\":\"" + LocalDateTime.now().plusMonths(6).toString() + "\"}"))
                 .andExpect(status().isNotFound());

--- a/src/test/java/edu/agh/dean/classesverifierbe/controller/StudentControllerTest.java
+++ b/src/test/java/edu/agh/dean/classesverifierbe/controller/StudentControllerTest.java
@@ -59,7 +59,7 @@ public class StudentControllerTest {
                 .role(Role.STUDENT)
                 .build();
 
-        mockMvc.perform(post("/student")
+        mockMvc.perform(post("/students")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(userDTO)))
                 .andExpect(status().isCreated());
@@ -69,7 +69,7 @@ public class StudentControllerTest {
     public void whenAddUserWithInvalidData_thenRespondWithBadRequest() throws Exception {
         String invalidUserJson = "{}";
 
-        mockMvc.perform(post("/student")
+        mockMvc.perform(post("/students")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(invalidUserJson))
                 .andExpect(status().isBadRequest());

--- a/src/test/java/edu/agh/dean/classesverifierbe/controller/StudentControllerTest.java
+++ b/src/test/java/edu/agh/dean/classesverifierbe/controller/StudentControllerTest.java
@@ -59,7 +59,7 @@ public class StudentControllerTest {
                 .role(Role.STUDENT)
                 .build();
 
-        mockMvc.perform(post("/student/")
+        mockMvc.perform(post("/student")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(userDTO)))
                 .andExpect(status().isCreated());
@@ -69,7 +69,7 @@ public class StudentControllerTest {
     public void whenAddUserWithInvalidData_thenRespondWithBadRequest() throws Exception {
         String invalidUserJson = "{}";
 
-        mockMvc.perform(post("/student/")
+        mockMvc.perform(post("/student")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(invalidUserJson))
                 .andExpect(status().isBadRequest());

--- a/src/test/java/edu/agh/dean/classesverifierbe/controller/SubjectControllerTest.java
+++ b/src/test/java/edu/agh/dean/classesverifierbe/controller/SubjectControllerTest.java
@@ -58,7 +58,7 @@ class SubjectControllerTest {
         when(subjectService.getAllSubjects(eq("Math"), eq("Algebra"), any(Pageable.class)))
                 .thenReturn(pageOfSubjects);
 
-        mockMvc.perform(get("/subject")
+        mockMvc.perform(get("/subjects")
                         .param("tags", "Math")
                         .param("name", "Algebra"))
                 .andExpect(status().isOk())
@@ -76,7 +76,7 @@ class SubjectControllerTest {
         Subject subject = new Subject();
         when(subjectService.addTagToSubject(anyLong(), anyLong())).thenReturn(subject);
 
-        mockMvc.perform(post("/subject/1/tags/1")
+        mockMvc.perform(post("/subjects/1/tags/1")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk());
 
@@ -88,7 +88,7 @@ class SubjectControllerTest {
 
         when(subjectService.addTagToSubject(anyLong(), anyLong())).thenThrow(new SubjectNotFoundException("subjectId"));
 
-        mockMvc.perform(post("/subject/999/tags/1")
+        mockMvc.perform(post("/subjects/999/tags/1")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isNotFound());
     }
@@ -113,7 +113,7 @@ class SubjectControllerTest {
         when(subjectService.getUsersEnrolledInSubjectForSemester(subjectId, semesterId)).thenReturn(mockUsers);
 
 
-        mockMvc.perform(get("/subject/{subjectId}/users", subjectId)
+        mockMvc.perform(get("/subjects/{subjectId}/users", subjectId)
                         .param("semesterId", semesterId.toString())
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
@@ -137,7 +137,7 @@ class SubjectControllerTest {
         when(subjectService.getUsersEnrolledInSubjectForSemester(subjectId, semesterId))
                 .thenThrow(new SubjectNotFoundException());
 
-        mockMvc.perform(get("/subject/{subjectId}/users", subjectId)
+        mockMvc.perform(get("/subjects/{subjectId}/users", subjectId)
                         .param("semesterId", semesterId.toString())
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isNotFound());

--- a/src/test/java/edu/agh/dean/classesverifierbe/controller/SubjectControllerTest.java
+++ b/src/test/java/edu/agh/dean/classesverifierbe/controller/SubjectControllerTest.java
@@ -58,7 +58,7 @@ class SubjectControllerTest {
         when(subjectService.getAllSubjects(eq("Math"), eq("Algebra"), any(Pageable.class)))
                 .thenReturn(pageOfSubjects);
 
-        mockMvc.perform(get("/subjects/")
+        mockMvc.perform(get("/subject")
                         .param("tags", "Math")
                         .param("name", "Algebra"))
                 .andExpect(status().isOk())
@@ -76,7 +76,7 @@ class SubjectControllerTest {
         Subject subject = new Subject();
         when(subjectService.addTagToSubject(anyLong(), anyLong())).thenReturn(subject);
 
-        mockMvc.perform(post("/subjects/1/tags/1")
+        mockMvc.perform(post("/subject/1/tags/1")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk());
 
@@ -88,7 +88,7 @@ class SubjectControllerTest {
 
         when(subjectService.addTagToSubject(anyLong(), anyLong())).thenThrow(new SubjectNotFoundException("subjectId"));
 
-        mockMvc.perform(post("/subjects/999/tags/1")
+        mockMvc.perform(post("/subject/999/tags/1")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isNotFound());
     }
@@ -113,7 +113,7 @@ class SubjectControllerTest {
         when(subjectService.getUsersEnrolledInSubjectForSemester(subjectId, semesterId)).thenReturn(mockUsers);
 
 
-        mockMvc.perform(get("/subjects/{subjectId}/users", subjectId)
+        mockMvc.perform(get("/subject/{subjectId}/users", subjectId)
                         .param("semesterId", semesterId.toString())
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
@@ -137,7 +137,7 @@ class SubjectControllerTest {
         when(subjectService.getUsersEnrolledInSubjectForSemester(subjectId, semesterId))
                 .thenThrow(new SubjectNotFoundException());
 
-        mockMvc.perform(get("/subjects/{subjectId}/users", subjectId)
+        mockMvc.perform(get("/subject/{subjectId}/users", subjectId)
                         .param("semesterId", semesterId.toString())
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isNotFound());

--- a/src/test/java/edu/agh/dean/classesverifierbe/controller/SubjectTagControllerTest.java
+++ b/src/test/java/edu/agh/dean/classesverifierbe/controller/SubjectTagControllerTest.java
@@ -44,7 +44,7 @@ class SubjectTagControllerTest {
 
         given(tagService.createTag(any(SubjectTagDTO.class))).willReturn(createdTag);
 
-        mockMvc.perform(post("/tag")
+        mockMvc.perform(post("/tags")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"name\":\"Math\",\"description\":\"Mathematics Description\"}"))
                 .andExpect(status().isCreated())
@@ -58,7 +58,7 @@ class SubjectTagControllerTest {
         Long tagId = 999L;
         given(tagService.getTag(tagId)).willThrow(new SubjectTagNotFoundException());
 
-        mockMvc.perform(get("/tag/{tagId}", tagId))
+        mockMvc.perform(get("/tags/{tagId}", tagId))
                 .andExpect(status().isNotFound());
 
         verify(tagService).getTag(tagId);
@@ -77,7 +77,7 @@ class SubjectTagControllerTest {
         updatedTag.setSubjectTagId(tagIntId);
         given(tagService.updateTag(eq(tagId), any(SubjectTagDTO.class))).willReturn(updatedTag);
 
-        mockMvc.perform(put("/tag/{tagId}", tagId)
+        mockMvc.perform(put("/tags/{tagId}", tagId)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"name\":\"UpdatedName\",\"description\":\"Updated Description\"}"))
                 .andExpect(status().isOk())

--- a/src/test/java/edu/agh/dean/classesverifierbe/controller/SubjectTagControllerTest.java
+++ b/src/test/java/edu/agh/dean/classesverifierbe/controller/SubjectTagControllerTest.java
@@ -44,7 +44,7 @@ class SubjectTagControllerTest {
 
         given(tagService.createTag(any(SubjectTagDTO.class))).willReturn(createdTag);
 
-        mockMvc.perform(post("/tags/")
+        mockMvc.perform(post("/tag")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"name\":\"Math\",\"description\":\"Mathematics Description\"}"))
                 .andExpect(status().isCreated())
@@ -58,7 +58,7 @@ class SubjectTagControllerTest {
         Long tagId = 999L;
         given(tagService.getTag(tagId)).willThrow(new SubjectTagNotFoundException());
 
-        mockMvc.perform(get("/tags/{tagId}", tagId))
+        mockMvc.perform(get("/tag/{tagId}", tagId))
                 .andExpect(status().isNotFound());
 
         verify(tagService).getTag(tagId);
@@ -77,7 +77,7 @@ class SubjectTagControllerTest {
         updatedTag.setSubjectTagId(tagIntId);
         given(tagService.updateTag(eq(tagId), any(SubjectTagDTO.class))).willReturn(updatedTag);
 
-        mockMvc.perform(put("/tags/{tagId}", tagId)
+        mockMvc.perform(put("/tag/{tagId}", tagId)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"name\":\"UpdatedName\",\"description\":\"Updated Description\"}"))
                 .andExpect(status().isOk())


### PR DESCRIPTION
- endpoint names kept only in plural form
-  delete ending slash from endpoint names