### PR TITLE
IO-63(test-enrolled-subjects)

### DIFF
--- a/src/test/java/edu/agh/dean/classesverifierbe/controller/EnrollmentControllerTest.java
+++ b/src/test/java/edu/agh/dean/classesverifierbe/controller/EnrollmentControllerTest.java
@@ -1,0 +1,118 @@
+package edu.agh.dean.classesverifierbe.controller;
+
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.agh.dean.classesverifierbe.exceptions.UserNotFoundException;
+import edu.agh.dean.classesverifierbe.model.Enrollment;
+import edu.agh.dean.classesverifierbe.model.enums.EnrollStatus;
+import edu.agh.dean.classesverifierbe.service.EnrollmentService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(EnrollmentController.class)
+class EnrollmentControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private EnrollmentService enrollmentService;
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        this.objectMapper = new ObjectMapper();
+    }
+    @Test
+    void whenGetEnrolledSubjectsByUserId_thenReturnEmptyList() throws Exception {
+
+        Long userId = 1L;
+        given(enrollmentService.getEnrolledSubjectsByUserId(userId)).willReturn(Collections.emptyList());
+
+
+        mockMvc.perform(get("/enrollment/user/{userId}", userId)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(content().json("[]"));
+
+        verify(enrollmentService, times(1)).getEnrolledSubjectsByUserId(userId);
+    }
+
+    @Test
+    void whenGetEnrolledSubjectsByUserId_thenReturnNonEmptyList() throws Exception {
+
+        Long userId = 1L;
+        Enrollment enrollment = new Enrollment();
+        enrollment.setEnrollmentId(1L);
+
+
+        List<Enrollment> expectedEnrollments = Collections.singletonList(enrollment);
+        given(enrollmentService.getEnrolledSubjectsByUserId(userId)).willReturn(expectedEnrollments);
+
+
+        mockMvc.perform(get("/enrollment/user/{userId}", userId)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$[0].enrollmentId").value(expectedEnrollments.get(0).getEnrollmentId()));
+
+        verify(enrollmentService, times(1)).getEnrolledSubjectsByUserId(userId);
+    }
+
+
+    @Test
+    public void confirmEnrollmentSingleTest() throws Exception {
+
+        Long enrollmentId = 1L;
+        Enrollment enrollment = new Enrollment();
+        when(enrollmentService.acceptEnrollment(enrollmentId)).thenReturn(enrollment);
+
+        mockMvc.perform(put("/enrollment/accept/" + enrollmentId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+
+        verify(enrollmentService).acceptEnrollment(enrollmentId);
+    }
+
+    @Test
+    public void confirmEnrollmentMultipleTest() throws Exception {
+
+        List<Long> enrollmentIds = Arrays.asList(1L, 2L, 3L);
+        List<Enrollment> enrollments = Arrays.asList(new Enrollment(), new Enrollment(), new Enrollment());
+        when(enrollmentService.acceptEnrollments(enrollmentIds)).thenReturn(enrollments);
+
+        mockMvc.perform(put("/enrollment/accept")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(enrollmentIds)))
+                .andExpect(status().isOk());
+
+        verify(enrollmentService).acceptEnrollments(enrollmentIds);
+    }
+
+
+
+}

--- a/src/test/java/edu/agh/dean/classesverifierbe/service/EnrollmentServiceTest.java
+++ b/src/test/java/edu/agh/dean/classesverifierbe/service/EnrollmentServiceTest.java
@@ -1,0 +1,157 @@
+package edu.agh.dean.classesverifierbe.service;
+
+import edu.agh.dean.classesverifierbe.dto.EnrollDTO;
+import edu.agh.dean.classesverifierbe.exceptions.EnrollmentNotFoundException;
+import edu.agh.dean.classesverifierbe.exceptions.UserNotFoundException;
+import edu.agh.dean.classesverifierbe.model.Enrollment;
+import edu.agh.dean.classesverifierbe.model.Semester;
+import edu.agh.dean.classesverifierbe.model.Subject;
+import edu.agh.dean.classesverifierbe.model.User;
+import edu.agh.dean.classesverifierbe.model.enums.EnrollStatus;
+import edu.agh.dean.classesverifierbe.repository.EnrollmentRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+class EnrollmentServiceTest {
+
+    @Mock
+    private EnrollmentRepository enrollmentRepository;
+
+    @Mock
+    private StudentService studentService;
+
+    @Mock
+    private SemesterService semesterService;
+
+    @Mock
+    private SubjectService subjectService;
+
+    @InjectMocks
+    private EnrollmentService enrollmentService;
+
+
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void whenGetEnrolledSubjectsByUserId_thenReturnsEmptyList() throws UserNotFoundException {
+
+        Long userId = 1L;
+        when(studentService.getRawUserById(userId)).thenReturn(new User());
+        when(enrollmentRepository.findAllByEnrollStudent_UserId(userId)).thenReturn(Collections.emptyList());
+
+        List<Enrollment> result = enrollmentService.getEnrolledSubjectsByUserId(userId);
+
+        verify(studentService, times(1)).getRawUserById(userId);
+        verify(enrollmentRepository, times(1)).findAllByEnrollStudent_UserId(userId);
+        assertTrue(result.isEmpty(), "The result should be an empty list");
+    }
+
+    @Test
+    void whenGetEnrolledSubjectsByUserId_thenReturnsNonEmptyList() throws UserNotFoundException {
+
+        Long userId = 1L;
+        User user = new User();
+        user.setUserId(userId);
+
+        Enrollment enrollment = new Enrollment();
+        enrollment.setEnrollmentId(1L);
+        enrollment.setEnrollStudent(user);
+
+
+        List<Enrollment> expectedEnrollments = Collections.singletonList(enrollment);
+        when(studentService.getRawUserById(userId)).thenReturn(user);
+        when(enrollmentRepository.findAllByEnrollStudent_UserId(userId)).thenReturn(expectedEnrollments);
+
+
+        List<Enrollment> actualEnrollments = enrollmentService.getEnrolledSubjectsByUserId(userId);
+
+
+        verify(studentService, times(1)).getRawUserById(userId);
+        verify(enrollmentRepository, times(1)).findAllByEnrollStudent_UserId(userId);
+        assertFalse(actualEnrollments.isEmpty(), "The result should not be an empty list");
+        assertEquals(expectedEnrollments.size(), actualEnrollments.size(), "The size of returned enrollments should match");
+        assertEquals(expectedEnrollments.get(0).getEnrollmentId(), actualEnrollments.get(0).getEnrollmentId(), "The enrollment IDs should match");
+    }
+
+    @Test
+    void whenUpdateEnrollmentForUser_thenUpdateStatus() throws Exception {
+
+        EnrollDTO enrollDTO = EnrollDTO.builder()
+                .userId(1L)
+                .subjectId(1L)
+                .enrollStatus(EnrollStatus.ACCEPTED)
+                .build();
+
+        enrollDTO.setEnrollStatus(EnrollStatus.ACCEPTED);
+
+        User user = new User();
+        user.setUserId(enrollDTO.getUserId());
+        Subject subject = new Subject();
+        subject.setSubjectId(enrollDTO.getSubjectId());
+        Semester semester = new Semester();
+        Enrollment existingEnrollment = new Enrollment();
+        existingEnrollment.setEnrollStudent(user);
+        existingEnrollment.setEnrollSubject(subject);
+        existingEnrollment.setSemester(semester);
+        existingEnrollment.setEnrollStatus(EnrollStatus.PENDING);
+
+        when(studentService.getRawUserById(enrollDTO.getUserId())).thenReturn(user);
+        when(subjectService.getSubjectById(enrollDTO.getSubjectId())).thenReturn(subject);
+        when(semesterService.getCurrentSemester()).thenReturn(semester);
+        when(enrollmentRepository.findEnrollmentByEnrollStudentAndEnrollSubjectAndSemester(user, subject, semester))
+                .thenReturn(Optional.of(existingEnrollment));
+        when(enrollmentRepository.save(existingEnrollment)).thenReturn(existingEnrollment);
+
+        assertEquals(EnrollStatus.PENDING, existingEnrollment.getEnrollStatus());
+
+        Enrollment updatedEnrollment = enrollmentService.updateEnrollmentForUser(enrollDTO);
+
+        assertNotNull(updatedEnrollment);
+        assertEquals(EnrollStatus.ACCEPTED, updatedEnrollment.getEnrollStatus());
+        verify(enrollmentRepository).save(existingEnrollment);
+    }
+
+
+    @Test
+    void whenAcceptEnrollments_thenStatusForEachEnrollmentIsACCEPTED() throws EnrollmentNotFoundException {
+
+        List<Long> enrollmentIds = Arrays.asList(1L, 2L);
+        List<Enrollment> enrollments = enrollmentIds.stream()
+                .map(id -> {
+                    Enrollment enrollment = new Enrollment();
+                    enrollment.setEnrollmentId(id);
+                    enrollment.setEnrollStatus(EnrollStatus.PENDING);
+                    return enrollment;
+                })
+                .collect(Collectors.toList());
+
+        when(enrollmentRepository.findAllById(enrollmentIds)).thenReturn(enrollments);
+
+        List<Enrollment> updatedEnrollments = enrollmentService.acceptEnrollments(enrollmentIds);
+
+        for (Enrollment enrollment : updatedEnrollments) {
+            assertEquals(EnrollStatus.ACCEPTED, enrollment.getEnrollStatus(), "Enrollment status should be ACCEPTED");
+        }
+        verify(enrollmentRepository).findAllById(enrollmentIds);
+        verify(enrollmentRepository).saveAll(enrollments);
+    }
+
+
+
+}


### PR DESCRIPTION
added tests for enrollmentService and enrollmentController including:
- Tests for EnrollmentService to check empty and non-empty lists of enrollments for a user and to update an enrollment status.
- Tests for EnrollmentController to ensure proper handling of accepting both single and multiple enrollments, with correct service method invocations and HTTP response statuses.